### PR TITLE
Event timezone feature

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -28,6 +28,7 @@ class Event extends Model
         'description',
         'started_at',
         'finished_at',
+        'timezone',
     ];
 
     /**

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 class Event extends Model
 {
@@ -75,6 +76,50 @@ class Event extends Model
     }
 
     /**
+     * Override the started_at setter.
+     */
+    public function setStartedAtAttribute($value)
+    {
+        $this->attributes['started_at'] = empty($value) ? null : Carbon::parse($value);
+    }
+
+    /**
+     * Override the finished_at setter.
+     */
+    public function setFinishedAtAttribute($value)
+    {
+        $this->attributes['finished_at'] = empty($value) ? null : Carbon::parse($value);
+    }
+
+    /**
+     * Override the started_at getter.
+     *
+     * @return Carbon
+     */
+    public function getStartedAtAttribute()
+    {
+        if (empty($this->attributes['started_at'])) {
+            return null;
+        }
+
+        return Carbon::parse($this->attributes['started_at'])->setTimezone($this->attributes['timezone']);
+    }
+
+    /**
+     * Override the finished_at getter.
+     *
+     * @return Carbon
+     */
+    public function getFinishedAtAttribute()
+    {
+        if (empty($this->attributes['finished_at'])) {
+            return null;
+        }
+
+        return Carbon::parse($this->attributes['finished_at'])->setTimezone($this->attributes['timezone']);
+    }
+
+    /**
      * Get the checklist before commit the event.
      */
     public function getCommitChecklist()
@@ -82,11 +127,11 @@ class Event extends Model
         return [
             [
                 'name' => 'The event has a start time after the current time.',
-                'is_fulfilled' => $this->started_at && $this->started_at > now(),
+                'is_fulfilled' => $this->started_at && $this->started_at->isFuture(),
             ],
             [
                 'name' => 'The event has a finish time after the start time.',
-                'is_fulfilled' => $this->finished_at && $this->finished_at > $this->started_at,
+                'is_fulfilled' => $this->finished_at && $this->finished_at->greaterThan($this->started_at),
             ],
             [
                 'name' => 'The event has at least two options',

--- a/app/Traits/TimeConverter.php
+++ b/app/Traits/TimeConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Traits;
+
+use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
+
+trait TimeConverter
+{
+    /**
+     * Convert string time to server time that defined in config.
+     *
+     * @param string|null $time The time to convert.
+     * @param string|null $timezone If `null`, the timezone will be assumed to 'UTC'.
+     * @return Carbon|null The converted time, or `null` if the time is `null` or the timezone is invalid.
+     */
+    public function convertStringTimeToServerTime(?string $time, $timezone = null)
+    {
+        if (empty($time)) {
+            return null;
+        }
+
+        try {
+            $time = Carbon::parse($time, $timezone);
+        } catch (InvalidFormatException $e) {
+            return null;
+        }
+
+        return $time->setTimezone(config('app.timezone', 'UTC'));
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -24,6 +24,7 @@ class EventFactory extends Factory
             'description' => $this->faker->paragraphs(3, true),
             'started_at' => $this->faker->dateTimeBetween('-1 days'),
             'finished_at' => $this->faker->dateTimeBetween('now', '+1 days'),
+            'timezone' => $this->faker->timezone,
         ];
     }
 }

--- a/database/migrations/2022_05_31_063047_create_events_table.php
+++ b/database/migrations/2022_05_31_063047_create_events_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->text('description')->nullable();
             $table->timestamp('started_at')->nullable();
             $table->timestamp('finished_at')->nullable();
+            $table->string('timezone')->nullable()->default('UTC');
             $table->boolean('is_committed')->default(false);
         });
     }

--- a/resources/views/pages/event-add.blade.php
+++ b/resources/views/pages/event-add.blade.php
@@ -12,7 +12,7 @@
     <hr>
     <form action="{{ route('events.store') }}" method="POST">
         @csrf
-        <div class="form-outline mb-4">
+        <div class="form-outline mb-3">
             <label class="form-label" for="title">
               <span>Title</span>
               <span style="color:red;font-weight:bold">*</span>
@@ -24,7 +24,7 @@
                 </span>
             @enderror
         </div>
-        <div class="form-outline mb-4">
+        <div class="form-outline mb-3">
             <label for="description" class="form-label">
                 <span>Description</span>
             </label>
@@ -36,18 +36,33 @@
                 </span>
             @enderror
         </div>
-        <div class="form-outline mb-2">
+        <div class="form-outline mb-3">
+            <label for="timezone" class="form-label">Timezone</label>
+            <input type="text" list="timezoneList" class="form-control @error('timezone') is-invalid @enderror" id="timezone" name="timezone" placeholder="Set the event timezone" value="{{ old('timezone') }}">
+            <datalist id="timezoneList">
+                @foreach (DateTimeZone::listIdentifiers() as $timezone)
+                    <option value="{{ $timezone }}">{{ $timezone }} ({{ now($timezone)->getOffsetString() }})</option>
+                @endforeach
+            </datalist>
+            @error('timezone')
+                <span class="invalid-feedback" role="alert">
+                    <strong>{{ $message }}</strong>
+                </span>
+            @enderror
+            <span class="form-text">Set the timezone for this event. For example: <b>Asia/Jakarta</b> or <b>UTC</b></span>
+        </div>
+        <div class="form-outline mb-3">
             <label for="startedAt" class="form-label">
               <span>Started At</span>
               <span style="color:red;font-weight:bold">*</span>
             </label>
-            <input type="datetime-local" class="form-control @error('started_at') is-invalid @enderror" id="startedAt" name="started_at" placeholder="Started At" min="{{ Date::now()->format('Y-m-d H:i') }}" value="{{ old('started_at') }}">
+            <input type="datetime-local" class="form-control @error('started_at') is-invalid @enderror" id="startedAt" name="started_at" placeholder="Started At" value="{{ old('started_at') }}">
             @error('started_at')
                 <span class="invalid-feedback" role="alert">
                     <strong>{{ $message }}</strong>
                 </span>
             @enderror
-            <span class="form-text">This date using UTC timezone.</span>
+            <span class="form-text">The start time should be more than now.</span>
         </div>
         <div class="form-outline mb-3">
             <label for="finishedAt" class="form-label">Finished At</label>
@@ -57,7 +72,7 @@
                     <strong>{{ $message }}</strong>
                 </span>
             @enderror
-            <span class="form-text">This date using UTC timezone.</span>
+            <span class="form-text">The finish time should be more than the start time.</span>
         </div>
         <button type="submit" class="btn btn-primary">{{ __('Add Event') }}</button>
     </form>

--- a/resources/views/pages/event-edit.blade.php
+++ b/resources/views/pages/event-edit.blade.php
@@ -13,7 +13,7 @@
     <form action="{{ route('events.update', ['event' => $event]) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="form-group mb-2">
+        <div class="form-group mb-3">
             <label for="title" class="form-label">Title</label>
             <input type="text" class="form-control @error('title') is-invalid @enderror" id="title" name="title" placeholder="Title" value="{{ old('title') ?? $event->title }}">
             @error('title')
@@ -22,7 +22,7 @@
                 </span>
             @enderror
         </div>
-        <div class="form-group mb-2">
+        <div class="form-group mb-3">
             <label for="description" class="form-label">Description</label>
             <input id="description" type="hidden" name="description" value="{{ old('description', $event->description) }}">
             <trix-editor input="description"></trix-editor>
@@ -32,15 +32,30 @@
                 </span>
             @enderror
         </div>
-        <div class="form-group mb-2">
+         <div class="form-outline mb-3">
+            <label for="timezone" class="form-label">Timezone</label>
+            <input type="text" list="timezoneList" class="form-control @error('timezone') is-invalid @enderror" id="timezone" name="timezone" placeholder="Set the event timezone" value="{{ old('timezone', $event->timezone) }}">
+            <datalist id="timezoneList">
+                @foreach (DateTimeZone::listIdentifiers() as $timezone)
+                    <option value="{{ $timezone }}">{{ $timezone }} ({{ now($timezone)->getOffsetString() }})</option>
+                @endforeach
+            </datalist>
+            @error('timezone')
+                <span class="invalid-feedback" role="alert">
+                    <strong>{{ $message }}</strong>
+                </span>
+            @enderror
+            <span class="form-text">Set the timezone for this event. For example: <b>Asia/Jakarta</b> or <b>UTC</b>.</span>
+        </div>
+        <div class="form-group mb-3">
             <label for="startedAt" class="form-label">Started At</label>
-            <input type="datetime-local" class="form-control @error('started_at') is-invalid @enderror" id="startedAt" name="started_at" placeholder="Started At" min="{{ Date::now()->format('Y-m-d H:i') }}" value="{{ old('started_at') ?? $event->started_at }}">
+            <input type="datetime-local" class="form-control @error('started_at') is-invalid @enderror" id="startedAt" name="started_at" placeholder="Started At" value="{{ old('started_at') ?? $event->started_at }}">
             @error('started_at')
                 <span class="invalid-feedback" role="alert">
                     <strong>{{ $message }}</strong>
                 </span>
             @enderror
-            <p class="form-text">This date using UTC timezone.</p>
+            <span class="form-text">The start time should be more than now.</span>
         </div>
         <div class="form-group mb-3">
             <label for="finishedAt" class="form-label">Finished At</label>
@@ -50,7 +65,7 @@
                     <strong>{{ $message }}</strong>
                 </span>
             @enderror
-            <p class="form-text">This date using UTC timezone.</p>
+            <span class="form-text">The finish time should be more than the start time.</span>
         </div>
         <button type="submit" class="btn btn-primary">{{ __('Edit Event') }}</button>
     </form>


### PR DESCRIPTION
### Changelog
- Create "timezone" field in "events" table.
- Add timezone input in Add Event Page and Edit Event Page.
- Convert `started_at` and `finished_at` from local timezone to server timezone in UTC.
- Create validation for timezone input.
- Convert `started_at` and `finished_at` from server timezone to local timezone.
- Override `started_at` and `finished_at` getter and setter to display the local time.